### PR TITLE
Improve the CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,30 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - hhvm
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.4
+      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
+    - php: 5.6
+      env: DEPENDENCIES=dev
+  allow_failures:
+    - php: 7.0
+    - php: hhvm
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
-before_script:
+before_install:
   - composer self-update
-  - composer install --no-interaction
-  - mkdir -p /tmp/jcalderonzumba/phantomjs
+  - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+
+install:
+  - composer update $COMPOSER_FLAGS
 
 script:
   - bin/run-tests.sh

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "guzzlehttp/guzzle": "~5.0"
   },
   "require-dev": {
-    "symfony/process": "~2.0",
+    "symfony/process": "~2.1",
+    "symfony/phpunit-bridge": "~2.7",
     "phpunit/phpunit": "~4.6",
     "silex/silex": "~1.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require": {
-    "php": ">=5.3",
+    "php": ">=5.4",
     "guzzlehttp/guzzle": "~5.0"
   },
   "require-dev": {


### PR DESCRIPTION
- Test against PHP 7 and HHVM
- Test against lowest deps (to ensure that the lower bound is right) and against dev deps (to catch errors before their release when possible)
- Persist only the composer download cache to avoid invalidating for Packagist metadata updates on each build
- Add the Symfony PHPunit bridge to make the testsuite fail when using deprecated APIs

this is the same than https://github.com/jcalderonzumba/MinkPhantomJSDriver/pull/36
