### PR TITLE
allow to set js_errors on startup

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,9 +6,11 @@ This statement can change in the future but that will require all clients to upg
 
 ##Start the Browser and the API
 ```bash
-phantomjs --ssl-protocol=any --ignore-ssl-errors=true vendor/jcalderonzumba/gastonjs/src/Client/main.js 8510 1024 768 2>&1 >> /tmp/gastonjs.log &
+phantomjs --ssl-protocol=any --ignore-ssl-errors=true vendor/jcalderonzumba/gastonjs/src/Client/main.js 8510 1024 768 false 2>&1 >> /tmp/gastonjs.log &
 ```
-This will start a phantomjs process and the API listening on the 8510 port, the 1024x768 parameters are the width and height you want the browser to use. You can start the API on the port you want 8510 is just an example.
+This will start a phantomjs process and the API listening on the 8510 port, the 1024x768 parameters are the width and
+height you want the browser to use. The "false" argument is about [JavaScript errors](commands/javascript/set_js_errors.md),
+if omitted it'll be "true" by default. You can start the API on the port you want, 8510 is just an example.
 
 ##API endpoint
 Your client can start making HTTP POST requests to `http://localhost:8510/v1/api`

--- a/src/Client/browser.js
+++ b/src/Client/browser.js
@@ -19,14 +19,15 @@ Poltergeist.Browser = (function () {
    * @param owner
    * @param width
    * @param height
+   * @param jsErrors
    * @constructor
    */
-  function Browser(owner, width, height) {
+  function Browser(owner, width, height, jsErrors) {
     this.owner = owner;
     this.width = width || 1024;
     this.height = height || 768;
     this.pages = [];
-    this.js_errors = true;
+    this.js_errors = (typeof jsErrors === 'boolean') ? jsErrors : true;
     this._debug = false;
     this._counter = 0;
     this.resetPage();

--- a/src/Client/main.js
+++ b/src/Client/main.js
@@ -26,4 +26,4 @@ phantom.injectJs("" + phantom.libraryPath + "/browser.js");
 
 system = require('system');
 
-new Poltergeist(system.args[1], system.args[2], system.args[3]);
+new Poltergeist(system.args[1], system.args[2], system.args[3], system.args[4] === 'false' ? false : true);

--- a/src/Client/poltergeist.js
+++ b/src/Client/poltergeist.js
@@ -5,11 +5,12 @@ Poltergeist = (function () {
    * @param port
    * @param width
    * @param height
+   * @param jsErrors
    * @constructor
    */
-  function Poltergeist(port, width, height) {
+  function Poltergeist(port, width, height, jsErrors) {
     var self;
-    this.browser = new Poltergeist.Browser(this, width, height);
+    this.browser = new Poltergeist.Browser(this, width, height, jsErrors);
 
     this.commandServer = new Poltergeist.Server(this, port);
     this.commandServer.start();


### PR DESCRIPTION
Would avoid to have to make a command call after phantomjs is started.
